### PR TITLE
fix(cli): use relative require in bin

### DIFF
--- a/bin/rlsr.js
+++ b/bin/rlsr.js
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
 
-const rlsr = require('rlsr');
+const rlsr = require('../src');
 
 rlsr(process.argv[2]);


### PR DESCRIPTION
the rlsr package can not be resolved when this is installed globally