### PR TITLE
Involve dev & peer dependencies

### DIFF
--- a/spec/polish-package.spec.js
+++ b/spec/polish-package.spec.js
@@ -1,0 +1,45 @@
+/* eslint-env node, jest */
+
+const polishPackages = require('../src/tools/polish-package');
+
+describe('polish-package', () => {
+  it('decorates a package with meta data', () => {
+    const nsp = 'foolsr';
+    const packages = ['foo', 'bar', 'baz'];
+    const pkg = {
+      dependencies: {
+        foo: '0.0.0',
+        baz: '9999.0.1'
+      }
+    };
+
+    expect(polishPackages(nsp, packages)(pkg)).toEqual({
+      dependencies: {
+        baz: "9999.0.1",
+        foo: "0.0.0",
+      },
+      [nsp]: {
+        dependencies: [
+          'foo',
+          'baz',
+        ],
+        determinedIncrementLevel: -1,
+        messages: [],
+        relatedMessages: [],
+        relations: [],
+      },
+    });
+  });
+
+  it('does not add unknown dependencies', () => {
+    const nsp = 'drrrt';
+    const packages = ['foo', 'bar', 'baz'];
+    const pkg = {
+      dependencies: {
+        drrt: '0.666.0'
+      }
+    };
+
+    expect(polishPackages(nsp, packages)(pkg)[nsp].dependencies).toEqual([]);
+  });
+});

--- a/spec/polish-package.spec.js
+++ b/spec/polish-package.spec.js
@@ -42,4 +42,28 @@ describe('polish-package', () => {
 
     expect(polishPackages(nsp, packages)(pkg)[nsp].dependencies).toEqual([]);
   });
+
+  it('adds peerDependencies', () => {
+    const nsp = 'noet';
+    const packages = ['foo', 'bar', 'baz'];
+    const pkg = {
+      peerDependencies: {
+        baz: '7.8.9'
+      }
+    };
+
+    expect(polishPackages(nsp, packages)(pkg)[nsp].dependencies).toEqual(['baz']);
+  });
+
+  it('adds devDependencies', () => {
+    const nsp = 'fp';
+    const packages = ['foo', 'bar', 'baz'];
+    const pkg = {
+      devDependencies: {
+        foo: '1.1.0'
+      }
+    };
+
+    expect(polishPackages(nsp, packages)(pkg)[nsp].dependencies).toEqual(['foo']);
+  });
 });

--- a/spec/update-version-number.spec.js
+++ b/spec/update-version-number.spec.js
@@ -12,7 +12,7 @@ const packages = {
       determinedIncrementLevel: -1,
       messages: [{level: 0}],
       relatedMessages: [],
-      relations: ['two']
+      relations: ['two', 'three']
     }
   },
   two: {
@@ -26,7 +26,19 @@ const packages = {
       relatedMessages: [],
       relations: []
     }
-  }
+  },
+  three: {
+    name: 'three',
+    devDependencies: {
+      one: '1.0.0'
+    },
+    rlsr: {
+      determinedIncrementLevel: -1,
+      messages: [],
+      relatedMessages: [],
+      relations: []
+    }
+  },
 };
 
 describe('updateVersionNumber()', () => {
@@ -72,10 +84,13 @@ describe('updateVersionNumber()', () => {
     const p = R.clone(packages);
     p.one.rlsr.messages[0].level = t[1];
     p.two.dependencies.one = t[2];
+    p.three.devDependencies.one = t[2];
 
     updateVersionNumber('rlsr', p)(p.one);
 
     expect(p.two.dependencies.one).toEqual(t[3]);
+    expect(p.three.devDependencies.one).toEqual(t[3]);
     expect(p.two.rlsr.determinedIncrementLevel).toEqual(t[4]);
+    expect(p.three.rlsr.determinedIncrementLevel).toEqual(-1);
   }));
 });

--- a/src/tools/dependency-types.js
+++ b/src/tools/dependency-types.js
@@ -1,0 +1,5 @@
+
+exports.KEY_DEPENDENCIES = 'dependencies';
+exports.KEY_PEER_DEPENDENCIES = 'peerDependencies';
+exports.KEY_DEV_DEPENDENCIES = 'devDependencies';
+exports.dependencyKeys = [exports.KEY_DEPENDENCIES, exports.KEY_PEER_DEPENDENCIES, exports.KEY_DEV_DEPENDENCIES];

--- a/src/tools/polish-package.js
+++ b/src/tools/polish-package.js
@@ -1,12 +1,20 @@
 const R = require('ramda');
 
+const dependencyKeys = require('./dependency-types').dependencyKeys;
+
+function gatherDependencies(pkg, keys) {
+  return dependencyKeys.reduce((result, key) => {
+    return result.concat(pkg[key] ? Object.keys(pkg[key]) : []);
+  }, []);
+}
+
 module.exports = (nsp, pkgNames) => pkg => {
   pkg[nsp] = Object.assign({}, pkg[nsp], {
     messages: [],
     relatedMessages: [],
     relations: [],
     determinedIncrementLevel: -1,
-    dependencies: pkg.dependencies ? Object.keys(pkg.dependencies).filter(depName => R.contains(depName, pkgNames)) : []
+    dependencies: gatherDependencies(pkg).filter(depName => R.contains(depName, pkgNames))
   });
   return pkg;
 };

--- a/src/tools/update-version-number.js
+++ b/src/tools/update-version-number.js
@@ -2,12 +2,21 @@ const semver = require('./semver');
 
 const RLSR_LATEST_DECLARATION = 'rlsr-latest';
 
+const KEY_DEV_DEPENDENCIES = require('./dependency-types').KEY_DEV_DEPENDENCIES;
+const dependencyKeys = require('./dependency-types').dependencyKeys;
+
 function getNewRange(newVersion, oldRange) {
   if (oldRange === RLSR_LATEST_DECLARATION) {
     return `^${newVersion}`;
   }
 
   return semver.adjustRange(newVersion, oldRange);
+}
+
+function getDependencyTypes(pkg, name) {
+  return dependencyKeys.filter((key) => {
+    return pkg[key] && pkg[key][name];
+  });
 }
 
 module.exports = (nsp, packages) => pkg => {
@@ -18,10 +27,19 @@ module.exports = (nsp, packages) => pkg => {
   pkg.version = semver.bump(pkg.version, pkg[nsp].determinedIncrementLevel);
   pkg[nsp].relations.forEach(rel => {
     const relatedPackage = packages[rel];
-    const oldRange = relatedPackage.dependencies[pkg.name];
-    const newRange = getNewRange(pkg.version, oldRange);
-    relatedPackage.dependencies[pkg.name] = newRange;
-    if (oldRange !== newRange && relatedPackage[nsp].determinedIncrementLevel === -1) {
+    const dependencyTypes = getDependencyTypes(relatedPackage, pkg.name);
+    const isOnlyDev = dependencyTypes.length === 1 && dependencyTypes[0] === KEY_DEV_DEPENDENCIES;
+
+    const hasUpdate = dependencyTypes.reduce((result, key) => {
+      const oldRange = relatedPackage[key][pkg.name];
+      const newRange = getNewRange(pkg.version, oldRange);
+
+      relatedPackage[key][pkg.name] = newRange;
+
+      return result || oldRange !== newRange;
+    }, false);
+
+    if (hasUpdate && !isOnlyDev && relatedPackage[nsp].determinedIncrementLevel === -1) {
       relatedPackage[nsp].determinedIncrementLevel = 0;
       relatedPackage[nsp].relatedMessages = relatedPackage[nsp].relatedMessages.concat(
         pkg[nsp].messages.map(m => Object.assign(


### PR DESCRIPTION
this change also bumps ranges of related packages when they're declared as peer- or devDependency.

devDependency-only updates will not trigger ack-releases

PTAL @matthias-reis 