### PR TITLE
fix: make breaking change regex case sensitive

### DIFF
--- a/src/read/getParsedCommitMessages.js
+++ b/src/read/getParsedCommitMessages.js
@@ -2,7 +2,7 @@ const commits = require('git-raw-commits');
 const parser = require('conventional-commits-parser');
 const R = require('ramda');
 
-const BREAKING_REGEXP = /BREAKING/i;
+const BREAKING_REGEXP = /BREAKING/;
 const PATCH_TYPES = ['fix', 'refactor', 'perf', 'revert'];
 const MINOR_TYPES = ['feat'];
 


### PR DESCRIPTION
in order to not trigger a major change when using the word "breaking" in a commit message to describe something and not explicitly stating a BREAKING CHANGE.