### PR TITLE
Scope to name map

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,9 @@ RLSR has some config values, that you can set inside your package.json in a
   (defaults to `./packages`)
 * `exactRelations` (boolean): use the exact paradigm for related versions
   (defaults to false)
+* `scopeToNameMap` (object): map commit message scopes to a different package
+  names. For example to use a shorter name in scopes or to handle renaming of
+  packages.
 
 ## rlsr-latest
 

--- a/src/read/getParsedCommitMessages.js
+++ b/src/read/getParsedCommitMessages.js
@@ -18,7 +18,17 @@ const addBreaking = msg => {
   });
 };
 
-module.exports = tag =>
+const scopeToName = map => msg => {
+  if (map[msg.scope]) {
+    return Object.assign({}, msg, {
+      scope: map[msg.scope]
+    });
+  }
+
+  return msg;
+};
+
+module.exports = (tag, scopeToNameMap) =>
   new Promise((resolve, reject) => {
     const commitMessages = [];
 
@@ -30,7 +40,11 @@ module.exports = tag =>
       .on('error', err => reject(err))
       .on('end', () => {
         resolve(
-          commitMessages.filter(isRelevant).map(addLevel).map(addBreaking)
+          commitMessages
+            .filter(isRelevant)
+            .map(scopeToName(scopeToNameMap))
+            .map(addLevel)
+            .map(addBreaking)
         );
       });
   });

--- a/src/read/index.js
+++ b/src/read/index.js
@@ -14,7 +14,7 @@ module.exports = env => {
     .then(tag => {
       env.log(`last semver tag <${tag}>`);
       return Promise.all([
-        getParsedCommitMessages(tag),
+        getParsedCommitMessages(tag, env.config.scopeToNameMap || {}),
         getPackages(
           path.join(env.appRoot, env.config.packagePath),
           env.consts.nsp


### PR DESCRIPTION
see #40

adds support for a `scopeToNameMap` config option which enables support for scoped packages, shorthand package names in scopes and renaming of packages.

Not sure if this feature is better be placed somewhere else.
There are no unit tests for the `read` action, so I did not add test for this either. Not sure where to put them.

This also includes a slightly related fix to the perform command (a8e410a). To stop assuming that the 
package name is the same as the package dir name.

PTAL @matthias-reis 