### PR TITLE
feat: create rlsr jso content

### DIFF
--- a/new/analyse/create-rlsr-json-content.ts
+++ b/new/analyse/create-rlsr-json-content.ts
@@ -1,0 +1,51 @@
+import type {
+  Module,
+  PackageAfterDetermineVersion,
+  RelatedPackageDependsOn,
+} from '../types';
+
+import { logger } from '../helpers/logger';
+
+const { error, log } = logger('[analyse] create rlsr json content');
+
+export const createRlsrJsonContent: Module = (env) => {
+  if (!env.packages) {
+    const errorMessage = 'missing "packages" on env object';
+    error(errorMessage);
+    throw new Error(errorMessage);
+  }
+
+  log('create rlsr.json content');
+
+  const packages = Object.fromEntries(
+    Object.entries(env.packages).map(([name, pkg]) => {
+      const dependencies = pkg.dependsOn.reduce(
+        (
+          accumulator: Record<string, RelatedPackageDependsOn>,
+          nextDependency
+        ) => {
+          accumulator[nextDependency.name] = nextDependency;
+          return accumulator;
+        },
+        {}
+      );
+      return [
+        name,
+        {
+          // if there was no increment, the version says as it was
+          version:
+            (pkg as PackageAfterDetermineVersion).incrementedVersion ??
+            pkg.currentVersion,
+          dependencies,
+        },
+      ];
+    })
+  );
+
+  const newStatus = {
+    lastReleaseHash: env.currentHash,
+    packages,
+  };
+
+  return { ...env, newStatus };
+};

--- a/new/analyse/fixtures/createMockPackage.ts
+++ b/new/analyse/fixtures/createMockPackage.ts
@@ -1,0 +1,20 @@
+import { Package, PackageAfterDetermineVersion } from '../../types';
+
+export const createMockPackage = (
+  name: string,
+  dependencies: Record<string, string> = {},
+  peerDependencies: Record<string, string> = {},
+  override: Partial<PackageAfterDetermineVersion> = {}
+): Package => {
+  return {
+    currentVersion: '1.0.0',
+    path: 'path/to/second/',
+    packageJson: { name, dependencies, peerDependencies },
+    messages: [],
+    relatedMessages: [],
+    determinedIncrementLevel: -1,
+    dependingOnThis: [],
+    dependsOn: [],
+    ...override,
+  };
+};

--- a/new/analyse/index.ts
+++ b/new/analyse/index.ts
@@ -12,6 +12,7 @@ import { determineVersion } from './determine-version';
 import { adaptDependencies } from './adapt-dependencies';
 import { prepareChangelogs } from './prepare-changelogs';
 import { createPackageJsonContent } from './create-package-json-content';
+import { createRlsrJsonContent } from './create-rlsr-json-content';
 
 export const analyse = composeAsync(
   log('ANALYSE PHASE: Looking at what needs to be changed'),
@@ -170,7 +171,7 @@ export const analyse = composeAsync(
   //   }
   // }
   // all the needed info is available, so this only has to be assembled together.
-  // createRlsrJsonContent
+  createRlsrJsonContent,
 
   // final final step
   // it might be worth spitting out some needed information

--- a/new/analyse/spec/add-dependencies.spec.ts
+++ b/new/analyse/spec/add-dependencies.spec.ts
@@ -6,6 +6,7 @@ import type {
   RelatedPackageDependsOn,
 } from '../../types';
 import { envWithConfig } from '../../fixtures/env';
+import { createMockPackage } from '../fixtures/createMockPackage';
 
 // mock Packages
 const mockPackageBuilder: (path: string, name: string) => Package = (
@@ -189,22 +190,3 @@ describe('addDependencies Module', () => {
     });
   });
 });
-
-const createMockPackage = (
-  name: string,
-  dependencies: Record<string, string> = {},
-  peerDependencies: Record<string, string> = {},
-  override: Partial<Package> = {}
-): Package => {
-  return {
-    currentVersion: '1.0.0',
-    path: 'path/to/second/',
-    packageJson: { name, dependencies, peerDependencies },
-    messages: [],
-    relatedMessages: [],
-    determinedIncrementLevel: -1,
-    dependingOnThis: [],
-    dependsOn: [],
-    ...override,
-  };
-};

--- a/new/analyse/spec/create-rlsr-json-content.spec.ts
+++ b/new/analyse/spec/create-rlsr-json-content.spec.ts
@@ -1,0 +1,107 @@
+/* eslint-env node, jest */
+import type { Env, Module } from '../../types';
+
+import { envWithConfig } from '../../fixtures/env';
+
+import { createMockPackage } from '../fixtures/createMockPackage';
+
+// mock Logger
+const mockError = jest.fn();
+const mockLog = jest.fn();
+const mockLogger = jest.fn(() => ({
+  error: mockError,
+  log: mockLog,
+}));
+jest.doMock('../../helpers/logger', () => ({
+  logger: mockLogger,
+}));
+
+describe('[analyse] createRlsrJsonContent module', () => {
+  let createRlsrJsonContent: Module;
+  beforeAll(() => {
+    createRlsrJsonContent =
+      require('../create-rlsr-json-content').createRlsrJsonContent;
+  });
+
+  it('throws an exception when "env.packages" is not defined', () => {
+    const expectedError = 'missing "packages" on env object';
+    expect(() => createRlsrJsonContent(envWithConfig)).toThrow(expectedError);
+    expect(mockError).toHaveBeenCalledTimes(1);
+    expect(mockError).toHaveBeenCalledWith(expectedError);
+  });
+
+  describe('on Run', () => {
+    let result: Env;
+
+    beforeAll(async () => {
+      const mockedEnv: Env = {
+        ...envWithConfig,
+        packages: {
+          package1: createMockPackage(
+            'package1',
+            {},
+            {},
+            {
+              currentVersion: '1.0.0',
+              incrementedVersion: '1.1.0',
+              dependsOn: [
+                {
+                  name: 'package2',
+                  range: '1-3',
+                  type: 'default',
+                },
+              ],
+            }
+          ),
+          package2: createMockPackage(
+            'package2',
+            {},
+            {},
+            {
+              currentVersion: '2.0.0',
+              dependsOn: [],
+            }
+          ),
+        },
+      };
+      result = await createRlsrJsonContent(mockedEnv);
+    });
+
+    it('adds the github commit hash', () => {
+      expect(result.newStatus).toBeDefined();
+      expect(result.newStatus?.lastReleaseHash).toEqual('hash');
+    });
+
+    it('adds all packages it finds', () => {
+      expect(result.newStatus?.packages).toHaveProperty('package1');
+      expect(result.newStatus?.packages).toHaveProperty('package2');
+    });
+
+    it('adds the incremented version if it finds any', () => {
+      expect(result.newStatus?.packages.package1).toHaveProperty(
+        'version',
+        '1.1.0'
+      );
+    });
+    it('keeps existing version if the package has not been touched', () => {
+      expect(result.newStatus?.packages.package2).toHaveProperty(
+        'version',
+        '2.0.0'
+      );
+    });
+    it('lists the dependencies', () => {
+      expect(result.newStatus?.packages.package1).toHaveProperty(
+        'dependencies'
+      );
+      expect(result.newStatus?.packages.package1.dependencies).toHaveProperty(
+        'package2'
+      );
+      expect(
+        result.newStatus?.packages.package1.dependencies.package2
+      ).toHaveProperty('type', 'default');
+      expect(
+        result.newStatus?.packages.package1.dependencies.package2
+      ).toHaveProperty('range', '1-3');
+    });
+  });
+});

--- a/new/fixtures/env.ts
+++ b/new/fixtures/env.ts
@@ -29,4 +29,5 @@ export const basicEnv: Env = {
 export const envWithConfig: Env = {
   ...basicEnv,
   config: defaultConfig,
+  currentHash: 'hash',
 };

--- a/new/types.ts
+++ b/new/types.ts
@@ -124,6 +124,8 @@ export type Env = {
   tagsInTree?: string[];
   /** Status from previous runs */
   status?: Status;
+  /** Status after the run to be written into the rlsr.json */
+  newStatus?: Status;
   /** Hash of the last commit */
   currentHash?: string;
   /** Hash of the initial commit */


### PR DESCRIPTION
Bringing the rlsr.json content together. For other steps, it helps to have a named object as deps, instead of an array.
